### PR TITLE
Bumped minimum required versions and declared HPOS support

### DIFF
--- a/gift-cards-coupon-input.php
+++ b/gift-cards-coupon-input.php
@@ -3,20 +3,20 @@
 * Plugin Name: Gift Cards - Coupon Input
 * Plugin URI: https://woocommerce.com/products/gift-cards
 * Description: Mini-extension for WooCommerce Gift Cards that allows you to use the default coupon form to apply and redeem gift cards.
-* Version: 1.0.3
+* Version: 1.1.0
 * Author: SomewhereWarm
 * Author URI: https://somewherewarm.com/
 *
 * Text Domain: woocommerce-gift-cards-coupon-input
 * Domain Path: /languages/
 *
-* Requires at least: 4.4
-* Tested up to: 6.3
+* Requires at least: 6.2
+* Tested up to: 6.6
 *
-* WC requires at least: 3.3
-* WC tested up to: 8.2
+* WC requires at least: 8.2
+* WC tested up to: 9.1
 *
-* Copyright: © 2017-2023 SomewhereWarm SMPC.
+* Copyright: © 2017-2024 SomewhereWarm SMPC.
 * License: GNU General Public License v3.0
 * License URI: http://www.gnu.org/licenses/gpl-3.0.html
 */
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Main plugin class.
  *
  * @class    WC_GC_Coupon_Input
- * @version  1.0.3
+ * @version  1.1.0
  */
 class WC_GC_Coupon_Input {
 
@@ -39,14 +39,14 @@ class WC_GC_Coupon_Input {
 	 *
 	 * @var string
 	 */
-	public static $version = '1.0.3';
+	public static $version = '1.1.0';
 
 	/**
 	 * Min required GC version.
 	 *
 	 * @var string
 	 */
-	public static $req_gc_version = '1.1.5';
+	public static $req_gc_version = '2.0';
 
 	/**
 	 * GC URL.
@@ -96,6 +96,9 @@ class WC_GC_Coupon_Input {
 		// Declare Blocks incompatibility.
 		add_action( 'before_woocommerce_init', array( __CLASS__, 'declare_blocks_compatibility' ) );
 
+		// Declare HPOS incompatibility.
+		add_action( 'before_woocommerce_init', array( __CLASS__, 'declare_hpos_compatibility' ) );
+
 		// Remove GC native form.
 		if ( version_compare( WC_GC()->get_plugin_version( true ), '1.7.0' ) < 0 ) {
 			remove_action( 'woocommerce_proceed_to_checkout', array( WC_GC()->cart, 'display_form' ), 9 );
@@ -137,6 +140,20 @@ class WC_GC_Coupon_Input {
 		}
 
 		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', plugin_basename( __FILE__ ), false );
+	}
+
+	/**
+	 * Declare HPOS incompatibility.
+	 *
+	 * @since 1.1.0
+	 */
+	public static function declare_hpos_compatibility() {
+
+		if ( ! class_exists( 'Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			return;
+		}
+
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', plugin_basename( __FILE__ ), true );
 	}
 
 	/**

--- a/gift-cards-coupon-input.php
+++ b/gift-cards-coupon-input.php
@@ -3,7 +3,7 @@
 * Plugin Name: Gift Cards - Coupon Input
 * Plugin URI: https://woocommerce.com/products/gift-cards
 * Description: Mini-extension for WooCommerce Gift Cards that allows you to use the default coupon form to apply and redeem gift cards.
-* Version: 1.1.0
+* Version: 2.0.0
 * Author: SomewhereWarm
 * Author URI: https://somewherewarm.com/
 *
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Main plugin class.
  *
  * @class    WC_GC_Coupon_Input
- * @version  1.1.0
+ * @version  2.0.0
  */
 class WC_GC_Coupon_Input {
 
@@ -39,7 +39,7 @@ class WC_GC_Coupon_Input {
 	 *
 	 * @var string
 	 */
-	public static $version = '1.1.0';
+	public static $version = '2.0';
 
 	/**
 	 * Min required GC version.
@@ -145,7 +145,7 @@ class WC_GC_Coupon_Input {
 	/**
 	 * Declare HPOS incompatibility.
 	 *
-	 * @since 1.1.0
+	 * @since 2.0.0
 	 */
 	public static function declare_hpos_compatibility() {
 

--- a/gift-cards-coupon-input.php
+++ b/gift-cards-coupon-input.php
@@ -39,7 +39,7 @@ class WC_GC_Coupon_Input {
 	 *
 	 * @var string
 	 */
-	public static $version = '2.0';
+	public static $version = '2.0.0';
 
 	/**
 	 * Min required GC version.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce-gift-cards-coupon-input",
 	"title": "Gift Cards - Coupon Input",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"homepage": "https://woocommerce.com/products/gift-cards/",
 	"license": "GPL-3.0+",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce-gift-cards-coupon-input",
 	"title": "Gift Cards - Coupon Input",
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"homepage": "https://woocommerce.com/products/gift-cards/",
 	"license": "GPL-3.0+",
 	"repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Gift Cards - Coupon Input ===
 
-Contributors: SomewhereWarm
+Contributors: automattic, woocommerce, SomewhereWarm
 Tags: woocommerce, gift, cards, coupon, input
 Requires at least: 6.2
 Tested up to: 6.6

--- a/readme.txt
+++ b/readme.txt
@@ -2,12 +2,12 @@
 
 Contributors: SomewhereWarm, franticpsyx, xristos3490
 Tags: woocommerce, gift, cards, coupon, input
-Requires at least: 4.4
-Tested up to: 6.3
-Stable tag: 1.0.3
-Requires PHP: 5.6
-WC requires at least: 3.3
-WC tested up to: 8.2
+Requires at least: 6.2
+Tested up to: 6.6
+Stable tag: 1.1.0
+Requires PHP: 7.4
+WC requires at least: 8.2
+WC tested up to: 9.1
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -32,6 +32,13 @@ This plugin requires the official [WooCommerce Gift Cards](https://woocommerce.c
 
 
 == Changelog ==
+
+= 1.1.0 =
+* Important - New: PHP 7.4+ is now required.
+* Important - New: WooCommerce 8.2+ is now required.
+* Important - New: WordPress 6.2+ is now required.
+* Important - New: Gift Cards 2.0+ is now required.
+* New - Declared compatibility with the new High-Performance order tables.
 
 = 1.0.3 =
 * Tweak - Declared support for WordPress 6.3 and WooCommerce 8.2.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SomewhereWarm, franticpsyx, xristos3490
 Tags: woocommerce, gift, cards, coupon, input
 Requires at least: 6.2
 Tested up to: 6.6
-Stable tag: 1.1.0
+Stable tag: 2.0.0
 Requires PHP: 7.4
 WC requires at least: 8.2
 WC tested up to: 9.1
@@ -33,7 +33,7 @@ This plugin requires the official [WooCommerce Gift Cards](https://woocommerce.c
 
 == Changelog ==
 
-= 1.1.0 =
+= 2.0.0 =
 * Important - New: PHP 7.4+ is now required.
 * Important - New: WooCommerce 8.2+ is now required.
 * Important - New: WordPress 6.2+ is now required.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Gift Cards - Coupon Input ===
 
-Contributors: SomewhereWarm, franticpsyx, xristos3490
+Contributors: SomewhereWarm
 Tags: woocommerce, gift, cards, coupon, input
 Requires at least: 6.2
 Tested up to: 6.6


### PR DESCRIPTION
### Description

This PR bumps the minimum required:
- PHP version to 7.4,
- WordPress version to 6.2, 
- WooCommerce version to 8.2 and;
- Gift Cards version to 2.

closes #8